### PR TITLE
Only check time_since in .bomboff if user == target

### DIFF
--- a/bombbot.py
+++ b/bombbot.py
@@ -361,10 +361,11 @@ def exclude(bot, trigger):
         if not trigger.admin and target != trigger.nick:
             bot.say(STRINGS['ADMINS_MARK_UNBOMBABLE'])
             return
-    time_since = time_since_bomb(bot, target)
-    if time_since < TIMEOUT and target == trigger.nick:
-        bot.notice(STRINGS['RECENTLY_PLANTED'] % (TIMEOUT - time_since), target)
-        return
+    if target == trigger.nick:
+        time_since = time_since_bomb(bot, target)
+        if time_since < TIMEOUT:
+            bot.notice(STRINGS['RECENTLY_PLANTED'] % (TIMEOUT - time_since), target)
+            return
     # Getting this far means all checks passed
     bot.db.set_nick_value(target, 'unbombable', True)
     bot.say(STRINGS['MARKED_UNBOMBABLE'] % target)


### PR DESCRIPTION
Saves hitting the database if an admin turns bombs off for a user on their behalf. Probably not strictly necessary, because that's actually a relatively rare use case, but I'm a perfectionist.