### PR TITLE
Settings refactor (resolves #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ Customized version of a custom version of a bomb module for sopel
 * User Controls:
   * `.bombon`/`.bomboff`: Lets users enable/disable being bombed at will. Admins can specify a nick.
 * Channel Controls
-  * `.bombson`/`.bombsoff`: Lets channel admins enable/disable bombing in the current channel.
-  * `.bombkickon`/`.bombkickoff`: Lets channel admins enable/disable kicking for bombs in the current channel.
+  * `.bombing [on|off]`: Lets channel admins enable/disable bombing in the current channel.
+  * `.bombkicks [on|off]`: Lets channel admins enable/disable kicking for bombs in the current channel.
 


### PR DESCRIPTION
Unified handling into a single callable. Takes "on"/"off" arguments instead of needing a dedicated command for each setting and state combination.

Renames and inverts the `bombs_disabled` setting to `bombing_allowed`. Includes migration routine that runs when performing checks during a call to `.bomb` (which writes the new setting and deletes the old). This migration might be changed before merging (e.g. to do it in bulk on load).